### PR TITLE
fix(deprecared) change addListener

### DIFF
--- a/src/app/home/home.page.ts
+++ b/src/app/home/home.page.ts
@@ -16,7 +16,7 @@ export class HomePage {
 
 	ngOnInit() {
 		const mediaDarkMode = window.matchMedia('(prefers-color-scheme: dark)');
-		mediaDarkMode.addListener(this.switchMode);
+		mediaDarkMode.addEventListener('change', this.switchMode);
 
 		this.initMap(mediaDarkMode.matches);
 	}


### PR DESCRIPTION
This feature is no longer recommended. Though some browsers might still support it, it may have already been removed from the relevant web standards, may be in the process of being dropped, or may only be kept for compatibility purposes. Avoid using it, and update existing code if possible; see the compatibility table  at the bottom of this page to guide your decision. Be aware that this feature may cease to work at any time.
The deprecated addListener() method of the MediaQueryList interface adds a listener to the MediaQueryListener that will run a custom callback function in response to the media query status changing.
In older browsers MediaQueryList did not yet inherit from EventTarget, so this method was provided as an alias of EventTarget.addEventListener(). Use addEventListener() instead of addListener() if it is available in the browsers you need to support.